### PR TITLE
resolve some manage-group bugs

### DIFF
--- a/src/app/layout/dashboard/components/default-meeting/default-meeting.component.ts
+++ b/src/app/layout/dashboard/components/default-meeting/default-meeting.component.ts
@@ -95,14 +95,15 @@ export class DefaultMeetingComponent implements OnInit, AfterViewInit {
         this._userService.getLoggedInUserObj().subscribe(data => {
             if (data.errorFl || data.warningFl) {
                 this.loggedInUser = {};
+                // this.loading = false;
                 return this.alertService.warning(data.message, 'Warning');
             } else {
                 this.loggedInUser = data;
                 this.isAdministrator = this.loggedInUser.roles.find(x => x.role === 'ADMINISTRATOR') !== undefined;
-                const payload = { userCode: this.loggedInUser.userCode };
-                this._meetingService.setFutureMeetimgList(payload);
+                // const payload = { userCode: this.loggedInUser.userCode };
                 this.futureMeetingList = [];
                 this._meetingService.getFutureMeetingListByUser().subscribe(futureData => {
+                    this.loading = true;
                     if (futureData !== undefined && futureData.length > 0) {
                         this.futureMeetingList = futureData;
                         this.filteredFutureMeetingList = futureData;
@@ -110,6 +111,12 @@ export class DefaultMeetingComponent implements OnInit, AfterViewInit {
                     } else {
                         this.futureMeetingList = [];
                         this.filteredFutureMeetingList = [];
+                        // if (this.filteredFutureMeetingList.length === 0 ) {
+                        //     this.loading = false;
+                        // }
+                        // if (JSON.stringify(futureData) === '{}') {
+                            // this.loading = false;
+                        // }
                         if (data[0] !== undefined && data[0].message !== undefined) {
                             this.loading = false;
                             return this.alertService.warning(data[0].message, 'Warning');

--- a/src/app/layout/dashboard/components/notification/notification.component.ts
+++ b/src/app/layout/dashboard/components/notification/notification.component.ts
@@ -63,6 +63,9 @@ export class NotificationComponent implements OnInit {
                 });
 
                 this._groupService.getGroupList().subscribe(groupData => {
+                    // if ( this.loading = false) {
+                    //     this.loading = true;
+                    // }
                     if (groupData !== undefined && groupData.length > 0) {
                         this.groupList = groupData;
                         // this.loading = false;

--- a/src/app/layout/dashboard/dashboard.component.ts
+++ b/src/app/layout/dashboard/dashboard.component.ts
@@ -104,6 +104,7 @@ export class DashboardComponent implements OnInit, AfterViewInit {
             } else {
                 this.loggedInUserObj = data;
                 const payload = { userCode: this.loggedInUserObj.userCode };
+                this._meetingService.setFutureMeetimgList(payload);
                 this._groupService.setGroupList(payload);
                 this._userService.setUserList(payload);
                 this._userService.setUserList(payload);

--- a/src/app/layout/manage-group/manage-group/manage-group.component.scss
+++ b/src/app/layout/manage-group/manage-group/manage-group.component.scss
@@ -94,7 +94,7 @@
   .group-name-list{
     height:70vh; 
     overflow: auto;
-    // padding-bottom: 100px;
+    padding-bottom: 100px;
   }
 
   .filter-list{

--- a/src/app/layout/manage-group/manage-group/manage-group.component.ts
+++ b/src/app/layout/manage-group/manage-group/manage-group.component.ts
@@ -144,21 +144,28 @@ export class ManageGroupComponent implements OnInit {
                 this._groupService.setGroupList(payload);
                 this._groupService.getGroupList().subscribe(groupData => {
                     if (groupData === undefined) {
-                        this.loading = false;
+                        // this.loading = false;
                         this.groupList = [];
                         return false;
                         // this.alertService.warning('There are no groups', 'Warning');
                     } else {
-                        if (groupData.errorFl === true || groupData.warningFl === true) {
+                        if (groupData.errorFl === true) {
                             this.groupList = [];
                             this.loading = false;
                             return this.alertService.warning(groupData.message, 'Warning');
+                        } else if (groupData.warningFl === true) {
+                            this.groupList = [];
+                            this.loading = false;
+                            return false;
                         } else {
                             // this code for avoid error onPageLoad of Cannot find a differ supporting object '[object Object]'
                             // for(let key in groupData) {
                             //     this.groupList.push(groupData[key]);
                             // }
                             this.groupList = groupData;
+                            // this.loading = false;
+                        }
+                        if (this.groupList.length > 0) {
                             this.loading = false;
                         }
                     }
@@ -354,6 +361,7 @@ export class ManageGroupComponent implements OnInit {
         }
     }
     updateMembers() {
+            this.loading = true;
             if (this.selectedMemberIds === null || this.selectedMemberIds === undefined || this.selectedMemberIds.length === 0) {
                 return this.alertService.warning('Please select members', 'Warning');
             } else {
@@ -383,6 +391,7 @@ export class ManageGroupComponent implements OnInit {
                         }
                         this.selectedItems = [];
                         this.selectedMemberIds = [];
+                        this.loading = false;
                         return this.alertService.success('Members has been updated successfully', 'Success');
                     });
                 }


### PR DESCRIPTION
- Resolve   bug in Manage Group, show spinner for loading the groups in the group list
- Resolve bug on laptop, in manage group , groups in the group   list hides
- In manage   group, when we select the members and click on update members button then   show a spinner loading till the response is received from the server and   added members are shown in the members data table.
- In manage group, when there are no members then remove the   warnings ui

